### PR TITLE
Remove running of rainfall module due to issue 17

### DIFF
--- a/src/eddie_floodresilience/dynamic_boundary_conditions/rainfall/rainfall_data_from_hirds.py
+++ b/src/eddie_floodresilience/dynamic_boundary_conditions/rainfall/rainfall_data_from_hirds.py
@@ -50,6 +50,7 @@ def get_site_url_key(site_id: str, idf: bool) -> str:
     data = f'{{"site_id":"{site_id}","idf":{idf}}}'
     # Make a POST request
     resp = requests.post(url, headers=headers, data=data)
+    resp.raise_for_status()
     # Convert the response to a DataFrame
     rainfall_results = pd.read_json(resp.text)
     # Get the unique URL key of the requested rainfall site

--- a/src/eddie_floodresilience/dynamic_boundary_conditions/rainfall/rainfall_sites.py
+++ b/src/eddie_floodresilience/dynamic_boundary_conditions/rainfall/rainfall_sites.py
@@ -69,6 +69,7 @@ def get_rainfall_sites_data() -> str:
     headers = get_hirds_headers()
     # Send HTTP GET request to the specified URL with headers
     response = requests.get(url, headers=headers)
+    response.raise_for_status()
     # Return the response content as a text string
     sites_data = response.text
     return sites_data

--- a/src/eddie_floodresilience/run_all.py
+++ b/src/eddie_floodresilience/run_all.py
@@ -21,8 +21,6 @@ import pathlib
 from eddie.digitaltwin import cache_new_results, retrieve_from_instructions
 from eddie.digitaltwin.utils import LogLevel
 from eddie.run_all import create_sample_polygon, main
-from src.eddie_floodresilience.dynamic_boundary_conditions.rainfall import main_rainfall
-from src.eddie_floodresilience.dynamic_boundary_conditions.rainfall.rainfall_enum import HyetoMethod, RainInputType
 from src.eddie_floodresilience.dynamic_boundary_conditions.river import main_river
 from src.eddie_floodresilience.dynamic_boundary_conditions.river.river_enum import BoundType
 from src.eddie_floodresilience.dynamic_boundary_conditions.tide import main_tide_slr
@@ -34,17 +32,6 @@ DEFAULT_MODULES_TO_PARAMETERS = {
         "instruction_json_path": pathlib.Path("src/eddie_floodresilience/static_boundary_instructions.json").as_posix()
     },
     process_hydro_dem: {
-        "log_level": LogLevel.INFO
-    },
-    main_rainfall: {
-        "rcp": 2.6,
-        "time_period": "2031-2050",
-        "ari": 100,
-        "storm_length_mins": 2880,
-        "time_to_peak_mins": 1440,
-        "increment_mins": 10,
-        "hyeto_method": HyetoMethod.ALT_BLOCK,
-        "input_type": RainInputType.UNIFORM,
         "log_level": LogLevel.INFO
     },
     main_tide_slr: {

--- a/src/eddie_floodresilience/tasks.py
+++ b/src/eddie_floodresilience/tasks.py
@@ -99,7 +99,6 @@ def create_model_for_area(selected_polygon_wkt: str, scenario_options: dict) -> 
     return (
         add_base_data_to_db.si(selected_polygon_wkt, base_data_parameters) |
         process_dem.si(selected_polygon_wkt) |
-        generate_rainfall_inputs.si(selected_polygon_wkt) |
         generate_tide_inputs.si(selected_polygon_wkt, scenario_options) |
         generate_river_inputs.si(selected_polygon_wkt) |
         run_flood_model.si(selected_polygon_wkt) |

--- a/tests/test_dynamic_boundary_conditions/rainfall/test_rainfall_data_from_hirds.py
+++ b/tests/test_dynamic_boundary_conditions/rainfall/test_rainfall_data_from_hirds.py
@@ -46,10 +46,10 @@ class RainfallDataFromHirdsTest(unittest.TestCase):
 
     @staticmethod
     def get_block_structures(
-            depth_layout: List[rainfall_data_from_hirds.BlockStructure],
-            intensity_layout: List[rainfall_data_from_hirds.BlockStructure],
-            start: Optional[int] = None,
-            end: Optional[int] = None) -> List[rainfall_data_from_hirds.BlockStructure]:
+        depth_layout: List[rainfall_data_from_hirds.BlockStructure],
+        intensity_layout: List[rainfall_data_from_hirds.BlockStructure],
+        start: Optional[int] = None,
+        end: Optional[int] = None) -> List[rainfall_data_from_hirds.BlockStructure]:
         """
         Get a list of BlockStructures from both depth and intensity layouts.
 
@@ -185,7 +185,11 @@ class RainfallDataFromHirdsTest(unittest.TestCase):
 
     @pytest.mark.skipif(
         EnvVariable.IS_ON_GITHUB_ACTIONS,
-        reason="Failing on GitHub Actions. See Issue https://github.com/GeospatialResearch/Digital-Twins/issues/367"
+        reason="""
+        Failing on GitHub Actions. See Issue https://github.com/GeospatialResearch/Digital-Twins/issues/367.
+        Also failing due to inaccessible API due to HIRDS API changes. 
+        See Issue https://github.com/GeospatialResearch/eddie_floodresilience/issues/17.
+        """
     )
     def test_get_data_from_hirds_not_empty(self):
         """Test to ensure that the rainfall depths and intensities data fetched from the HIRDS website is not empty."""


### PR DESCRIPTION
This does not close #17, but is a stop-gap to allow the project to run.

#17 HIRDS point data is no longer directly accessible via an API. In order to resolve this, we would need to access the underlying API from ESNZ, or use an alternate data source. Martin has access to a Raster format of the data but this requires entirely changing the rainfall module.

In the mean time, I propose we disable the rainfall module since it is not functioning at all without access to the API.


## Developer Checklist
- [x] Make code change
- [ ] Update tests
  - [ ] Update / create new tests
  - [ ] Ensure these tests have the expected behaviour
  - [ ] Test locally and ensure tests are passing
- [ ] Update documentation
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki

## Reviewer Checklist
- [ ] Check new code for code smells
- [ ] Check new tests
  - [ ] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [ ] Check if documentation needs updating
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki
